### PR TITLE
s/input/inputs/

### DIFF
--- a/SPEC.markdown
+++ b/SPEC.markdown
@@ -62,7 +62,7 @@ Block endpoints work with JSON objects containing input or output "records". An 
 	
 	{"foo": "string value for foo", "bar": 42}
 
-This is put inside an input envelope, which is just a single key JSON object with the key "input":
+This is put inside an input envelope, which is just a single key JSON object with the key "inputs":
 
 	{"inputs": {"foo": "string value for foo", "bar": 42}}
 


### PR DESCRIPTION
I believe this is correct for now. It looks like you've been oscillating back and forth between "input" and "inputs" being the key name. Is "inputs" the current verdict?
